### PR TITLE
Fix incorrect comparison.

### DIFF
--- a/src/cdflib.cpp
+++ b/src/cdflib.cpp
@@ -10040,7 +10040,7 @@ void negative_binomial_cdf_values ( int *n_data, int *f, int *s, double *p,
     1, 2, 3,
     0, 1, 2 };
 
-  if ( n_data < 0 )
+  if ( *n_data < 0 )
   {
     *n_data = 0;
   }


### PR DESCRIPTION
This comparison is a compiler error on clang, and on gcc it's legal but useless, since without the deference it's a comparison of a pointer (unsigned type) to 0, which is always false.